### PR TITLE
Revamp ProtocolLib

### DIFF
--- a/src/ProtocolLib/LogicException.php
+++ b/src/ProtocolLib/LogicException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ProtocolLib;
+
+class LogicException extends \LogicException {
+}

--- a/src/ProtocolLib/ProtocolHelper.php
+++ b/src/ProtocolLib/ProtocolHelper.php
@@ -12,8 +12,23 @@ class ProtocolHelper {
         return static::$cache[$interface];
     }
 
+    public static function getMethodProtocol($interface) {
+        if (!isset(static::$cache[$interface])) {
+            static::$cache[$interface] = new ProtocolMethodWrapper($interface);
+        }
+        return static::$cache[$interface];
+    }
+
     public static function doesImplement($obj, $interface) {
         return static::getProtocol($interface)->doesImplement($obj);
+    }
+
+    public static function doesMethodImplement($method, $interface) {
+        return static::getMethodProtocol($interface)->doesMethodImplement($method);
+    }
+
+    public static function doesFunctionImplement($function, $interface) {
+        return static::getMethodProtocol($interface)->doesFunctionImplement($function);
     }
 
 }

--- a/src/ProtocolLib/ProtocolMethodWrapper.php
+++ b/src/ProtocolLib/ProtocolMethodWrapper.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace ProtocolLib;
+
+class ProtocolMethodWrapper {
+
+    protected $reflector;
+
+    public function __construct($method) {
+        if (!$method instanceof \ReflectionMethod) {
+            try {
+                $method = new \ReflectionMethod($method);
+            } catch (\ReflectionException $e) {
+                throw new LogicException(sprintf(
+                    "Requested Interface Method Not Defined: %s",
+                    $method
+                ), null, $e);
+            }
+        }
+        if (!$method->getDeclaringClass()->isInterface()) {
+            throw new LogicException(sprintf(
+                "Declaring Class Of Requested Interface Method Is Not An Interface: %s",
+                $method->getDeclaringClass()->getName()
+            ));
+        }
+        $this->reflector = $method;
+    }
+
+    public function doesMethodImplement($method) {
+        if (!$method instanceof \ReflectionMethod) {
+            try {
+                if (is_array($method)) {
+                    $method = new \ReflectionMethod($method[0], $method[1]);
+                } else {
+                    $method = new \ReflectionMethod($method);
+                }
+            } catch (\ReflectionException $e) {
+                return false;
+            }
+        }
+        if ($this->reflector->name !== $method->name) {
+            return false;
+        }
+        $methodModifiers = $method->getModifiers();
+        $reflModifiers = $this->reflector->getModifiers();
+        foreach (array(
+            \ReflectionMethod::IS_STATIC,
+            \ReflectionMethod::IS_PUBLIC,
+            \ReflectionMethod::IS_PROTECTED,
+            ) as $modifier) {
+            if (($methodModifiers & $modifier) !== ($reflModifiers & $modifier)) {
+                return false;
+            }
+        }
+        return $this->checkParams($method);
+    }
+
+    public function doesFunctionImplement($function) {
+        if (!$function instanceof \ReflectionFunction) {
+            try {
+                $function = new \ReflectionFunction($function);
+            } catch (\ReflectionException $e) {
+                return false;
+            }
+        }
+        return $this->checkParams($function);
+    }
+
+    protected function checkParams(\ReflectionFunctionAbstract $function) {
+        if ($function->getNumberOfParameters() !== $function->getNumberOfParameters()) {
+            return false;
+        }
+        $params = $this->reflector->getParameters();
+        foreach ($function->getParameters() as $key => $param) {
+            if (!$this->checkParam($param, $params[$key])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected function checkParam(\ReflectionParameter $param1, \ReflectionParameter $param2) {
+        if ($param1->isDefaultValueAvailable() !== $param2->isDefaultValueAvailable()) {
+            return false;
+        }
+        // Only check if a default value is available, otherwise it throws an
+        // exception (ReflectionException: Failed to retrieve the default value).
+        // http://php.net/reflectionparameter.getdefaultvalue.php#refsect1-reflectionparameter.getdefaultvalue-notes
+        if ($param1->isDefaultValueAvailable()) {
+            if ($param1->isDefaultValueConstant() !== $param2->isDefaultValueConstant()) {
+                return false;
+            }
+            // Should probably be omitted. Looks like default values of
+            // arguments don't have to match default values of the interface
+            // method. http://3v4l.org/XYT9k
+            if ($param1->getDefaultValue() !== $param2->getDefaultValue()) {
+                return false;
+            }
+            // Should be omitted for the reason above and because it returns the
+            // actual declaration.
+            //
+            // interface InterfaceWithConstantDefaultValue {
+            //     const TEST = 1;
+            //     function test($param = self::TEST);
+            // }
+            //
+            // class ClassWithConstantDefaultValue
+            // {
+            //     public function test($param = InterfaceWithConstantDefaultValue::TEST) {}
+            // }
+            //
+            // This would return "self::TEST" and "TestInterfaceWithConstantDefaultValue::TEST".
+            //
+            /*if ($param1->isDefaultValueConstant() && $param1->getDefaultValueConstantName() !== $param2->getDefaultValueConstantName()) {
+                return false;
+            }*/
+        }
+        foreach (array(
+            'isArray',
+            'isCallable',
+            'isOptional',
+            'isPassedByReference',
+            'canBePassedByValue',
+            'allowsNull',
+            ) as $check) {
+            if ($param1->$check() !== $param2->$check()) {
+                return false;
+            }
+        }
+        // ReflectionParameter::getClass() throws an exception if the class does
+        // not exist (ReflectionException: Class Foo\Bar does not exist).
+        $class1 = null;
+        $class2 = null;
+        try {
+            if ($param1->getClass()) {
+                $class1 = $param1->getClass()->name;
+            }
+        } catch (\ReflectionException $e) {
+            if (!preg_match('/Class (.+) does not exist/', $e->getMessage(), $matches)) {
+                throw $e;
+            }
+            $class1 = $matches[1];
+        }
+        try {
+            if ($param2->getClass()) {
+                $class2 = $param2->getClass()->name;
+            }
+        } catch (\ReflectionException $e) {
+            if (!preg_match('/Class (.+) does not exist/', $e->getMessage(), $matches)) {
+                throw $e;
+            }
+            $class2 = $matches[1];
+        }
+        if ($class1 !== $class2) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/test/ProtocolLib/ProtocolMethodWrapperTest.php
+++ b/test/ProtocolLib/ProtocolMethodWrapperTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace ProtocolLib;
+
+class ProtocolMethodWrapperTest extends \PHPUnit_Framework_TestCase {
+
+    public function testConstruct() {
+        $obj = new ProtocolMethodWrapper('Iterator::current');
+    }
+
+    /**
+     * @expectedException ProtocolLib\LogicException
+     * @expectedExceptionMessage Requested Interface Method Not Defined: NonExtistingClass
+     */
+    public function testConstructNonExistingClassFailure() {
+        $obj = new ProtocolMethodWrapper('NonExtistingClass::foo');
+    }
+
+    /**
+     * @expectedException ProtocolLib\LogicException
+     * @expectedExceptionMessage Declaring Class Of Requested Interface Method Is Not An Interface: ProtocolLib\ProtocolMethodWrapperTest
+     */
+    public function testConstructNonInterfaceFailure() {
+        $obj = new ProtocolMethodWrapper('ProtocolLib\ProtocolMethodWrapperTest::testConstructNonInterfaceFailure');
+    }
+
+    public function testMethodImplementArguments() {
+        $protocol = new ProtocolMethodWrapper('ProtocolLib\TestInterfaceWithInternalClassTypehint::test');
+
+        $this->assertTrue($protocol->doesMethodImplement('ProtocolLib\TestClassWithInternalClassTypehint::test'));
+        $this->assertTrue($protocol->doesMethodImplement(array('ProtocolLib\TestClassWithInternalClassTypehint', 'test')));
+        $this->assertTrue($protocol->doesMethodImplement(array(new TestClassWithInternalClassTypehint, 'test')));
+    }
+
+    /**
+     * @dataProvider methodFunctionDataProvider
+     */
+    public function testImplement($type, $method, $function, $closure) {
+        foreach ($this->interfaceDataProvider() as $options) {
+            $protocol = new ProtocolMethodWrapper($options[1]);
+
+            $expected = $options[0] === $type ? true : false;
+
+            $this->assertSame($expected, $protocol->doesMethodImplement($method), $options[1].' -> method');
+            $this->assertSame($expected, $protocol->doesFunctionImplement($function), $options[1].' -> function');
+            $this->assertSame($expected, $protocol->doesFunctionImplement($closure), $options[1].' -> closure');
+        }
+    }
+
+    public function interfaceDataProvider()
+    {
+        return array(
+            'internal class typehint' => array(
+                'internal-class-typehint',
+                __NAMESPACE__.'\TestInterfaceWithInternalClassTypehint::test'
+            ),
+            'existing class typehint' => array(
+                'exisiting-class-typehint',
+                __NAMESPACE__.'\TestInterfaceWithExisitingClassTypehint::test'
+            ),
+            'non-existing class typehint' => array(
+                'non-exisiting-class-typehint',
+                __NAMESPACE__.'\TestInterfaceWithNonExisitingClassTypehint::test'
+            ),
+            'callable typehint' => array(
+                'callable-typehint',
+                __NAMESPACE__.'\TestInterfaceWithCallableTypehint::test'
+            ),
+            'array typehint' => array(
+                'array-typehint',
+                __NAMESPACE__.'\TestInterfaceWithArrayTypehint::test'
+            ),
+            'without typehint' => array(
+                'without-typehint',
+                __NAMESPACE__.'\TestInterfaceWithoutTypehint::test'
+            ),
+            'with null default value' => array(
+                'with-null-default-value',
+                __NAMESPACE__.'\TestInterfaceWithNullDefaultValue::test'
+            ),
+            'with internal constant default value' => array(
+                'with-internal-constant-default-value',
+                __NAMESPACE__.'\TestInterfaceWithInternalConstantDefaultValue::test'
+            ),
+            'with constant default value' => array(
+                'with-constant-default-value',
+                __NAMESPACE__.'\TestInterfaceWithConstantDefaultValue::test'
+            ),
+        );
+    }
+
+    public function methodFunctionDataProvider()
+    {
+        return array(
+            'internal class typehint' => array(
+                'internal-class-typehint',
+                __NAMESPACE__.'\TestClassWithInternalClassTypehint::test',
+                __NAMESPACE__.'\TestFunctionWithInternalClassTypehint',
+                function (\Traversable $param) {}
+            ),
+            'existing class typehint' => array(
+                'exisiting-class-typehint',
+                __NAMESPACE__.'\TestClassWithExisitingClassTypehint::test',
+                __NAMESPACE__.'\TestFunctionWithExisitingClassTypehint',
+                function (\stdClass $param) {}
+            ),
+            'non-existing class typehint' => array(
+                'non-exisiting-class-typehint',
+                __NAMESPACE__.'\TestClassWithNonExisitingClassTypehint::test',
+                __NAMESPACE__.'\TestFunctionWithNonExisitingClassTypehint',
+                function (NonExisitingClass $param) {}
+            ),
+            'callable typehint' => array(
+                'callable-typehint',
+                __NAMESPACE__.'\TestClassWithCallableTypehint::test',
+                __NAMESPACE__.'\TestFunctionWithCallableTypehint',
+                function (callable $param) {}
+            ),
+            'array typehint' => array(
+                'array-typehint',
+                __NAMESPACE__.'\TestClassWithArrayTypehint::test',
+                __NAMESPACE__.'\TestFunctionWithArrayTypehint',
+                function (array $param) {}
+            ),
+            'without typehint' => array(
+                'without-typehint',
+                __NAMESPACE__.'\TestClassWithoutTypehint::test',
+                __NAMESPACE__.'\TestFunctionWithoutTypehint',
+                function ($param) {}
+            ),
+            'with null default value' => array(
+                'with-null-default-value',
+                __NAMESPACE__.'\TestClassWithNullDefaultValue::test',
+                __NAMESPACE__.'\TestFunctionWithNullDefaultValue',
+                function ($param = null) {}
+            ),
+            'with internal constant default value' => array(
+                'with-internal-constant-default-value',
+                __NAMESPACE__.'\TestClassWithInternalConstantDefaultValue::test',
+                __NAMESPACE__.'\TestFunctionWithInternalConstantDefaultValue',
+                function ($param = \DIRECTORY_SEPARATOR) {}
+            ),
+            'with constant default value' => array(
+                'with-constant-default-value',
+                __NAMESPACE__.'\TestClassWithConstantDefaultValue::test',
+                __NAMESPACE__.'\TestFunctionWithConstantDefaultValue',
+                function ($param = TestInterfaceWithConstantDefaultValue::TEST) {}
+            ),
+        );
+    }
+}
+
+interface TestInterfaceWithInternalClassTypehint
+{
+    function test(\Traversable $param);
+}
+
+interface TestInterfaceWithExisitingClassTypehint
+{
+    function test(\stdClass $param);
+}
+
+interface TestInterfaceWithNonExisitingClassTypehint
+{
+    function test(NonExisitingClass $param);
+}
+
+interface TestInterfaceWithCallableTypehint
+{
+    function test(callable $param);
+}
+
+interface TestInterfaceWithArrayTypehint
+{
+    function test(array $param);
+}
+
+interface TestInterfaceWithoutTypehint
+{
+    function test($param);
+}
+
+interface TestInterfaceWithNullDefaultValue
+{
+    function test($param = null);
+}
+
+interface TestInterfaceWithInternalConstantDefaultValue
+{
+    function test($param = \DIRECTORY_SEPARATOR);
+}
+
+interface TestInterfaceWithConstantDefaultValue
+{
+    const TEST = 1;
+    function test($param = self::TEST);
+}
+
+// ---
+
+class TestClassWithInternalClassTypehint
+{
+    public function test(\Traversable $param) {}
+}
+
+class TestClassWithExisitingClassTypehint
+{
+    public function test(\stdClass $param) {}
+}
+
+class TestClassWithNonExisitingClassTypehint
+{
+    public function test(NonExisitingClass $param) {}
+}
+
+class TestClassWithCallableTypehint
+{
+    public function test(callable $param) {}
+}
+
+class TestClassWithArrayTypehint
+{
+    public function test(array $param) {}
+}
+
+class TestClassWithoutTypehint
+{
+    public function test($param) {}
+}
+
+class TestClassWithNullDefaultValue
+{
+    public function test($param = null) {}
+}
+
+class TestClassWithInternalConstantDefaultValue
+{
+    public function test($param = \DIRECTORY_SEPARATOR) {}
+}
+
+class TestClassWithConstantDefaultValue
+{
+    public function test($param = TestInterfaceWithConstantDefaultValue::TEST) {}
+}
+
+// ---
+
+function TestFunctionWithInternalClassTypehint(\Traversable $param) {}
+
+function TestFunctionWithExisitingClassTypehint(\stdClass $param) {}
+
+function TestFunctionWithNonExisitingClassTypehint(NonExisitingClass $param) {}
+
+function TestFunctionWithCallableTypehint(callable $param) {}
+
+function TestFunctionWithArrayTypehint(array $param) {}
+
+function TestFunctionWithoutTypehint($param) {}
+
+function TestFunctionWithNullDefaultValue($param = null) {}
+
+function TestFunctionWithInternalConstantDefaultValue($param = \DIRECTORY_SEPARATOR) {}
+
+function TestFunctionWithConstantDefaultValue($param = TestInterfaceWithConstantDefaultValue::TEST) {}

--- a/test/ProtocolLib/ProtocolWrapperTest.php
+++ b/test/ProtocolLib/ProtocolWrapperTest.php
@@ -9,9 +9,18 @@ class ProtocolWrapperTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException ProtocolLib\LogicException
+     * @expectedExceptionMessage Requested Interface Not Defined: NonExtistingClass
      */
-    public function testConstructFailure() {
+    public function testConstructNonExistingClassFailure() {
+        $obj = new ProtocolWrapper('NonExtistingClass');
+    }
+
+    /**
+     * @expectedException ProtocolLib\LogicException
+     * @expectedExceptionMessage Requested Interface Is Not An Interface: ProtocolLib\ProtocolWrapperTest
+     */
+    public function testConstructNonInterfaceFailure() {
         $obj = new ProtocolWrapper('ProtocolLib\ProtocolWrapperTest');
     }
 
@@ -25,6 +34,11 @@ class ProtocolWrapperTest extends \PHPUnit_Framework_TestCase {
         $obj = new ProtocolWrapper("Iterator");
         $ao = new \StdClass;
         $this->assertFalse($obj->doesImplement($ao));
+    }
+
+    public function testGetMethodProtocolReturnsMethodWrapper() {
+        $obj = new ProtocolWrapper("IteratorAggregate");
+        $this->assertTrue($obj->getMethodProtocol('getIterator')->doesMethodImplement('ArrayObject::getIterator'));
     }
 
 }


### PR DESCRIPTION
The intention was to implement #1, it's a little bit more now. I hope that's ok...

Backward compatibility should be preserved and i tried to stick with your coding style.

---
#### Moved method related logic into its own class ProtocolMethodWrapper which can be also used standalone

Examples:

``` php
$protocol = new ProtocolLib\ProtocolMethodWrapper('Interface::method');

$protocol->doesMethodImplement('Class::method');
// or
$protocol->doesMethodImplement(['Class', 'method']);
// or
$protocol->doesMethodImplement([$object, 'method']);
```

You can also obtain a method wrapper from the parent interface wrapper

``` php
$protocol = (new ProtocolLib\ProtocolWrapper('Interface'))->getMethodProtocol('method');
```

---
#### Added ProtocolMethodWrapper::doesFunctionImplement for checking if a function implements a specific interface method

Examples:

``` php
$protocol = new ProtocolLib\ProtocolMethodWrapper('Interface::method');

$protocol->doesFunctionImplement('function_name');
// or
$protocol->doesFunctionImplement(function (...) {
});
```

---
#### Heavily improved method/function parameter checks (ProtocolMethodWrapper::checkParam)

https://github.com/ircmaxell/Protocol-Lib/blob/function-implement/src/ProtocolLib/ProtocolMethodWrapper.php#L82-L158

---
#### Added a LogicException class under the ProtocolLib namespace
